### PR TITLE
feat: partial metadata hash ADR62

### DIFF
--- a/etc/hashing.api.md
+++ b/etc/hashing.api.md
@@ -28,6 +28,9 @@ export function hashV0(stream: AsyncGenerator<Uint8Array> | AsyncIterable<Uint8A
 // @public
 export function hashV1(content: AsyncGenerator<Uint8Array> | AsyncIterable<Uint8Array> | Uint8Array): Promise<string>;
 
+// @public
+export function keccak256Hash(metadata: any, keys: string[]): string;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "ethereum-cryptography": "^1.0.3",
         "ipfs-unixfs-importer": "^7.0.3",
         "multiformats": "^9.6.3"
       },
@@ -929,6 +930,22 @@
       "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
       "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.0.0.tgz",
+      "integrity": "sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg=="
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.5.5.tgz",
+      "integrity": "sha512-sZ1W6gQzYnu45wPrWx8D3kwI2/U29VYTx9OjbDAd7jwRItJ0cSTMPRL/C8AWZFn9kWFLQGqEXVEE86w4Z8LpIQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -1026,6 +1043,48 @@
         "argparse": "~1.0.9",
         "colors": "~1.2.1",
         "string-argv": "~0.3.1"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.0.0.tgz",
+      "integrity": "sha512-gIVaYhUsy+9s58m/ETjSJVKHhKTBMmcRb9cEV5/5dwvfDlfORjKrFsDeDHWRrm6RjcPvCLZFwGJjAjLj1gg4HA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.0.1.tgz",
+      "integrity": "sha512-AU88KKTpQ+YpTLoicZ/qhFhRRIo96/tlb+8YmDDHR9yiKVjSsFZiefJO4wjS2PMTkz5/oIcw84uAq/8pleQURA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/hashes": "~1.0.0",
+        "@noble/secp256k1": "~1.5.2",
+        "@scure/base": "~1.0.0"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.0.0.tgz",
+      "integrity": "sha512-HrtcikLbd58PWOkl02k9V6nXWQyoa7A0+Ek9VF7z17DDk9XZAFUcIdqfh0jJXLypmizc5/8P6OxoUeKliiWv4w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/hashes": "~1.0.0",
+        "@scure/base": "~1.0.0"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -1969,6 +2028,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ethereum-cryptography": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.0.3.tgz",
+      "integrity": "sha512-NQLTW0x0CosoVb/n79x/TRHtfvS3hgNUPTUSCu0vM+9k6IIhHFFrAOJReneexjZsoZxMjJHnJn4lrE8EbnSyqQ==",
+      "dependencies": {
+        "@noble/hashes": "1.0.0",
+        "@noble/secp256k1": "1.5.5",
+        "@scure/bip32": "1.0.1",
+        "@scure/bip39": "1.0.0"
       }
     },
     "node_modules/execa": {
@@ -5562,6 +5632,16 @@
       "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
       "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
     },
+    "@noble/hashes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.0.0.tgz",
+      "integrity": "sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg=="
+    },
+    "@noble/secp256k1": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.5.5.tgz",
+      "integrity": "sha512-sZ1W6gQzYnu45wPrWx8D3kwI2/U29VYTx9OjbDAd7jwRItJ0cSTMPRL/C8AWZFn9kWFLQGqEXVEE86w4Z8LpIQ=="
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -5661,6 +5741,30 @@
         "argparse": "~1.0.9",
         "colors": "~1.2.1",
         "string-argv": "~0.3.1"
+      }
+    },
+    "@scure/base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.0.0.tgz",
+      "integrity": "sha512-gIVaYhUsy+9s58m/ETjSJVKHhKTBMmcRb9cEV5/5dwvfDlfORjKrFsDeDHWRrm6RjcPvCLZFwGJjAjLj1gg4HA=="
+    },
+    "@scure/bip32": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.0.1.tgz",
+      "integrity": "sha512-AU88KKTpQ+YpTLoicZ/qhFhRRIo96/tlb+8YmDDHR9yiKVjSsFZiefJO4wjS2PMTkz5/oIcw84uAq/8pleQURA==",
+      "requires": {
+        "@noble/hashes": "~1.0.0",
+        "@noble/secp256k1": "~1.5.2",
+        "@scure/base": "~1.0.0"
+      }
+    },
+    "@scure/bip39": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.0.0.tgz",
+      "integrity": "sha512-HrtcikLbd58PWOkl02k9V6nXWQyoa7A0+Ek9VF7z17DDk9XZAFUcIdqfh0jJXLypmizc5/8P6OxoUeKliiWv4w==",
+      "requires": {
+        "@noble/hashes": "~1.0.0",
+        "@scure/base": "~1.0.0"
       }
     },
     "@sinonjs/commons": {
@@ -6397,6 +6501,17 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "ethereum-cryptography": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.0.3.tgz",
+      "integrity": "sha512-NQLTW0x0CosoVb/n79x/TRHtfvS3hgNUPTUSCu0vM+9k6IIhHFFrAOJReneexjZsoZxMjJHnJn4lrE8EbnSyqQ==",
+      "requires": {
+        "@noble/hashes": "1.0.0",
+        "@noble/secp256k1": "1.5.5",
+        "@scure/bip32": "1.0.1",
+        "@scure/bip39": "1.0.0"
+      }
     },
     "execa": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
+    "ethereum-cryptography": "^1.0.3",
     "ipfs-unixfs-importer": "^7.0.3",
     "multiformats": "^9.6.3"
   },

--- a/src/ADR62.ts
+++ b/src/ADR62.ts
@@ -6,7 +6,7 @@ import { toHex } from "ethereum-cryptography/utils"
  * @public
  */
 export function keccak256Hash(metadata: any, keys: string[]): string {
-  const partialMetadata = JSON.stringify(pick(metadata, keys.sort()))
+  const partialMetadata = JSON.stringify(pick(metadata, keys))
   const data = new TextEncoder().encode(partialMetadata)
   const hash = keccak256(data)
   return toHex(hash)

--- a/src/ADR62.ts
+++ b/src/ADR62.ts
@@ -1,15 +1,16 @@
 import { keccak256 } from "ethereum-cryptography/keccak"
+import { toHex } from "ethereum-cryptography/utils"
 
 /**
  * Calculates the metadata hash. Uses the keys to determine which fields of the metadata object will be used for the result.
  * @public
  */
-function keccak256Hash(metadata: any, keys: string[]): string {
-  const partialMetadata = JSON.stringify(pick(metadata, keys))
+export function keccak256Hash(metadata: any, keys: string[]): string {
+  const partialMetadata = JSON.stringify(pick(metadata, keys.sort()))
   const data = new TextEncoder().encode(partialMetadata)
   const hash = keccak256(data)
-  return new TextDecoder().decode(hash)
+  return toHex(hash)
 }
 
-const pick = (obj: { [x: string]: any }, ...keys: any[]) =>
+const pick = (obj: { [x: string]: any }, keys: string[]) =>
   Object.fromEntries(keys.filter((key) => key in obj).map((key) => [key, obj[key]]))

--- a/src/ADR62.ts
+++ b/src/ADR62.ts
@@ -1,0 +1,15 @@
+import { keccak256 } from "ethereum-cryptography/keccak"
+
+/**
+ * Calculates the metadata hash. Uses the keys to determine which fields of the metadata object will be used for the result.
+ * @public
+ */
+function keccak256Hash(metadata: any, keys: string[]): string {
+  const partialMetadata = JSON.stringify(pick(metadata, keys))
+  const data = new TextEncoder().encode(partialMetadata)
+  const hash = keccak256(data)
+  return new TextDecoder().decode(hash)
+}
+
+const pick = (obj: { [x: string]: any }, ...keys: any[]) =>
+  Object.fromEntries(keys.filter((key) => key in obj).map((key) => [key, obj[key]]))

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./node"
 export * from "./ADR32"
+export * from "./ADR62"

--- a/test/ADR62.spec.ts
+++ b/test/ADR62.spec.ts
@@ -78,7 +78,7 @@ describe('ADR62', () => {
 
     it('hashes metadata with merkle proof correctly', () => {
         const hash = keccak256Hash(metadataWithMerkleProof, metadataWithMerkleProof.merkleProof.hashingKeys)
-        expect(hash).toBe('9c3353049b2aa3236bf4977a36421a09ffec4e0c0982379561b08853da25fa37')
+        expect(hash).toBe('8282d378bafea28952d4bcce9b2bc1567ed2dda20eba629c8030752dd8169c43')
 
         const emptyMetadata = {}
         const noKeys = []
@@ -112,7 +112,7 @@ describe('ADR62', () => {
         expect(hashA).not.toBe(hashB)
     })
 
-    it('hashing metadata with keys in different order should result in same hash', () => {
+    it('hashing metadata with keys in different order should result in different hashes', () => {
         const metadata = {
             fieldA: 'fieldA',
             fieldB: 'fieldB'
@@ -121,13 +121,14 @@ describe('ADR62', () => {
         const hashA = keccak256Hash(metadata, ['fieldA', 'fieldB'])
         const hashB = keccak256Hash(metadata, ['fieldB', 'fieldA'])
 
-        expect(hashA).toBe(hashB)
+        expect(hashA).not.toBe(hashB)
     })
 
-    it('hashing metadata with keys in different order should result in same hash 2', () => {
-        const hashA = keccak256Hash(metadataWithMerkleProof, metadataWithMerkleProof.merkleProof.hashingKeys)
-        const hashB = keccak256Hash(metadataWithMerkleProof, metadataWithMerkleProof.merkleProof.hashingKeys.sort(() => Math.random() - 0.5))
+    it('hashing metadata with keys in different order should result in different hashes 2', () => {
+        const keys = metadataWithMerkleProof.merkleProof.hashingKeys
+        const hashA = keccak256Hash(metadataWithMerkleProof, keys)
+        const hashB = keccak256Hash(metadataWithMerkleProof, keys.reverse())
 
-        expect(hashA).toBe(hashB)
+        expect(hashA).not.toBe(hashB)
     })
 })

--- a/test/ADR62.spec.ts
+++ b/test/ADR62.spec.ts
@@ -1,0 +1,133 @@
+import { keccak256Hash } from "../src/ADR62"
+
+const metadataWithMerkleProof = {
+    id: "urn:decentraland:off-chain:base-avatars:aviatorstyle",
+    name: "Aviator Style",
+    description: "aDescription",
+    image: "image.png",
+    thumbnail: "thumbnail.png",
+    data: {
+      tags: ["male", "man", "base-wearable"],
+      category: "eyewear",
+      replaces: [],
+      hides: [],
+      representations: [
+        {
+          bodyShapes: ["urn:decentraland:off-chain:base-avatars:BaseMale"],
+          mainFile: "M_Eyewear_AviatorStyle.glb",
+          overrideReplaces: [],
+          overrideHides: [],
+          contents: ["M_Eyewear_AviatorStyle.glb"],
+        },
+      ],
+    },
+    i18n: [{ code: "en", text: "Aviator Style" }],
+    createdAt: 1646935739,
+    updatedAt: 1646935739,
+    metrics: {
+      triangles: 0,
+      materials: 0,
+      meshes: 0,
+      bodies: 0,
+      entities: 0,
+      textures: 0,
+    },
+    content: {
+      "some-file.glb": "3999dc565303be392b94568fe252fd09482c2329e3381b66d730f870cb6c2afa",
+      "thumbnail.png": "b9b9563ea35e1f995e272e9c699326ac61b94cfe46dc4f49b5215c94d3209854"
+    },
+    merkleProof: {
+      index: 61575,
+      proof: [
+        "0xc8ae2407cffddd38e3bcb6c6f021c9e7ac21fcc60be44e76e4afcb34f637d562",
+        "0x16123d205a70cdeff7643de64cdc69a0517335d9c843479e083fd444ea823172",
+        "0x1fbe73f1e71f11fb4e88de5404f3177673bdfc89e93d9a496849b4ed32c9b04f",
+        "0xed60c527e6774dbf6750f7e28dbf93c25a22660085f709c3a0a772606768fd91",
+        "0x7aff1c982d6a98544c126a0676ac98102533072b6c4506f31b413757e38f4c30",
+        "0x5f5170cdf5fdd7bb25c225d08b48361e41f05477880812f7f5954e75daa6c667",
+        "0x08ae25d236fa4105b2c5136938bc42f55d339f8e4d9feb776799681b8a8a48e7",
+        "0xadfcc425df780be50983856c7de4d405a3ec054b74020628a9d13fdbaff35df7",
+        "0xda4ee1c4148a25eefbef12a92cc6a754c6312c1ff15c059f46e049ca4e5ca43b",
+        "0x98c363c32c7b1d7914332efaa19ad2bee7e110d79d7690650dbe7ce8ba1002a2",
+        "0x0bd810301fbafeb4848f7b60a378c9017a452286836d19a108812682edf8a12a",
+        "0x1533c6b3879f90b92fc97ec9a1db86f201623481b1e0dc0eefa387584c5d93da",
+        "0x31c2c3dbf88646a964edd88edb864b536182619a02905eaac2a00b0c5a6ae207",
+        "0xc2088dbbecba4f7dd06c689b7c1a1e6a822d20d4665b2f9353715fc3a5f0d588",
+        "0x9e191109e34d166ac72033dce274a82c488721a274087ae97b62c9a51944e86f",
+        "0x5ff2905107fe4cce21c93504414d9548f311cd27efe5696c0e03acc059d2e445",
+        "0x6c764a5d8ded16bf0b04028b5754afbd216b111fa0c9b10f2126ac2e9002e2fa",
+      ],
+      hashingKeys: [
+        "id",
+        "name",
+        "description",
+        "image",
+        "thumbnail",
+        "data",
+        "i18n",
+        "createdAt",
+        "updatedAt",
+        "metrics",
+        "content"
+      ],
+      entityHash: "52c312f5e5524739388af971cddb526c3b49ba31ec77abc07ca01f5b113f1eba",
+    },
+  }
+
+describe('ADR62', () => {
+
+    it('hashes metadata with merkle proof correctly', () => {
+        const hash = keccak256Hash(metadataWithMerkleProof, metadataWithMerkleProof.merkleProof.hashingKeys)
+        expect(hash).toBe('9c3353049b2aa3236bf4977a36421a09ffec4e0c0982379561b08853da25fa37')
+
+        const emptyMetadata = {}
+        const noKeys = []
+        const emptyHash = keccak256Hash(emptyMetadata, noKeys)
+        expect(hash).not.toBe(emptyHash)
+    })
+
+    it('hashes metadata without matching keys is the same as empty metadata', () => {
+        const metadata = {
+            someField: 'someValue'
+        }
+        const keys = ['unknownField']
+        const hash = keccak256Hash(metadata, keys)
+        expect(hash).toBe('b48d38f93eaa084033fc5970bf96e559c33c4cdc07d889ab00b4d63f9590739d')
+
+        const emptyMetadata = {}
+        const noKeys = []
+        const emptyHash = keccak256Hash(emptyMetadata, noKeys)
+        expect(hash).toBe(emptyHash)
+    })
+
+    it('hashing metadata with different keys result in different hashes', () => {
+        const metadata = {
+            fieldA: 'fieldA',
+            fieldB: 'fieldB'
+        }
+
+        const hashA = keccak256Hash(metadata, ['fieldA'])
+        const hashB = keccak256Hash(metadata, ['fieldB'])
+
+        expect(hashA).not.toBe(hashB)
+    })
+
+    it('hashing metadata with keys in different order should result in same hash', () => {
+        const metadata = {
+            fieldA: 'fieldA',
+            fieldB: 'fieldB'
+        }
+
+        const hashA = keccak256Hash(metadata, ['fieldA', 'fieldB'])
+        const hashB = keccak256Hash(metadata, ['fieldB', 'fieldA'])
+
+        expect(hashA).toBe(hashB)
+    })
+
+    it('hashing metadata with keys in different order should result in same hash 2', () => {
+        const hashA = keccak256Hash(metadataWithMerkleProof, metadataWithMerkleProof.merkleProof.hashingKeys)
+        const hashB = keccak256Hash(metadataWithMerkleProof, metadataWithMerkleProof.merkleProof.hashingKeys.sort(() => Math.random() - 0.5))
+
+        expect(hashA).toBe(hashB)
+    })
+})

--- a/test/ADR62.spec.ts
+++ b/test/ADR62.spec.ts
@@ -113,18 +113,6 @@ describe('ADR62', () => {
     })
 
     it('hashing metadata with keys in different order should result in different hashes', () => {
-        const metadata = {
-            fieldA: 'fieldA',
-            fieldB: 'fieldB'
-        }
-
-        const hashA = keccak256Hash(metadata, ['fieldA', 'fieldB'])
-        const hashB = keccak256Hash(metadata, ['fieldB', 'fieldA'])
-
-        expect(hashA).not.toBe(hashB)
-    })
-
-    it('hashing metadata with keys in different order should result in different hashes 2', () => {
         const keys = metadataWithMerkleProof.merkleProof.hashingKeys
         const hashA = keccak256Hash(metadataWithMerkleProof, keys)
         const hashB = keccak256Hash(metadataWithMerkleProof, keys.reverse())


### PR DESCRIPTION
## Description

Adds a hashing method described in [ADR62](https://github.com/decentraland/adr/blob/main/docs/ADR-62-merkle-proofed-entities.md) which takes an object and some keys and returns a `keccak256` hash as string.