### PR TITLE
docs: note migration to core-libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # @dcl/hashing
 
+This package has been migrated to the [`core-libs`](https://github.com/decentraland/core-libs/tree/main/libs/hashing) monorepo.
+Future changes, issues, and releases are managed there.
+
 [![Coverage Status](https://coveralls.io/repos/github/decentraland/hashing/badge.svg?branch=main)](https://coveralls.io/github/decentraland/hashing?branch=main)
 
 Hashing functions to calculate Decentraland Content Identifiers


### PR DESCRIPTION
## Why

The package has moved to the `core-libs` monorepo, so the old repository should direct contributors and consumers to the new source of truth.

## How

- Added a migration notice at the top of the README.
- Linked to the new `libs/hashing` package location in `core-libs`.

## Verification

- Documentation-only change.
